### PR TITLE
Handle the empty simple catalog and update the function parameter

### DIFF
--- a/app/controllers/avatax/configuration_controller.rb
+++ b/app/controllers/avatax/configuration_controller.rb
@@ -14,7 +14,8 @@ module Avatax
     #
 
     def set_tax_code
-      @products = KillBillClient::Model::Catalog.simple_catalog(options_for_klient).last.products.map(&:name)
+      simple_catalog = KillBillClient::Model::Catalog.simple_catalog(nil, options_for_klient).last
+      @products = simple_catalog ? simple_catalog.products.map(&:name) : []
     end
 
     def do_set_tax_code


### PR DESCRIPTION
Here is the following issue: https://github.com/killbill/killbill-avatax-ui/issues/6
Updates: 
+ Update the simple_catalog function parameter: https://github.com/killbill/killbill-client-ruby/blob/0c897c2006f5a8e22bbc98176e91200ff02253cd/lib/killbill_client/models/catalog.rb#L10
+ Handle when the simple_catalog is empty