### PR TITLE
rename_killbill_assest_ui

### DIFF
--- a/lib/avatax/engine.rb
+++ b/lib/avatax/engine.rb
@@ -6,7 +6,7 @@
 # We need to explicitly require all of our dependencies listed in avatax.gemspec
 #
 # See also https://github.com/carlhuda/bundler/issues/49
-require 'killbill-assets-ui'
+require 'killbill_assets_ui'
 require 'killbill_client'
 
 module Avatax


### PR DESCRIPTION
Rename killbill-assest-ui to killbill_assets_ui.
Related PR: https://github.com/killbill/killbill-assets-ui/pull/8/files